### PR TITLE
Fix product page padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Removed redundant Spinner in _ProductPage_ Component.
+- Product page padding.
 
 ## [0.3.5] - 2018-05-21
 ### Fixed

--- a/react/ProductPage.js
+++ b/react/ProductPage.js
@@ -26,7 +26,7 @@ class ProductPage extends Component {
 
     return (
       <div>
-        <div className="pv9-ns">
+        <div className="pv2-ns">
           <div className="vtex-product-details-container">
             {!loading && (
               <ExtensionPoint

--- a/react/StoreTemplate.js
+++ b/react/StoreTemplate.js
@@ -13,7 +13,7 @@ export default class StoreTemplate extends Component {
     return (
       <div>
         <Header />
-        <div className="z-1 pb6">{this.props.children}</div>
+        <div className="z-1">{this.props.children}</div>
         <ExtensionPoint id="footer" />
       </div>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix product page padding that is pushing down the product-details component.

#### How should this be manually tested?
Access: https://andre--storecomponents.myvtex.com/ninja-300/p

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/2967288/40861320-027ed2b6-65bf-11e8-888f-e05324f76340.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
