### PR TITLE
Feature/logo integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Integration of logo component.
+
 ## [1.0.0] - 2018-6-4
 ### Added
 - Add the breadcrumb component to the SearchPage and ProductPage

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,7 @@
     "vtex.minicart": "0.x",
     "vtex.product-details": "0.x",
     "vtex.storecomponents": "1.x",
+    "vtex.store-components": "1.x",
     "vtex.gallery": "0.x",
     "vtex.category-menu": "0.x",
     "vtex.breadcrumb": "0.x",

--- a/react/Header.js
+++ b/react/Header.js
@@ -23,8 +23,8 @@ class Header extends Component {
 
   static propTypes = {
     name: PropTypes.string,
-    logoUrl: PropTypes.string.isRequired,
-    logoTitle: PropTypes.string.isRequired,
+    logoUrl: PropTypes.string,
+    logoTitle: PropTypes.string,
     intl: intlShape.isRequired,
   }
 

--- a/react/Header.js
+++ b/react/Header.js
@@ -23,6 +23,8 @@ class Header extends Component {
 
   static propTypes = {
     name: PropTypes.string,
+    logoUrl: PropTypes.string.isRequired,
+    logoTitle: PropTypes.string.isRequired,
     intl: intlShape.isRequired,
   }
 
@@ -85,7 +87,7 @@ class Header extends Component {
 
   render() {
     const { account } = global.__RUNTIME__
-    const { name } = this.props
+    const { name, logoUrl, logoTitle } = this.props
     const { isAddToCart, hasError, showMenuPopup, error } = this.state
 
     return (
@@ -98,11 +100,18 @@ class Header extends Component {
         <div className="z-2 items-center w-100 top-0 bg-white tl">
           <ExtensionPoint id="menu-link" />
         </div>
-        <TopMenu name={name || account} />
+        <TopMenu 
+          logoUrl={logoUrl}
+          logoTitle={logoTitle}
+        />
         <ExtensionPoint id="category-menu" />
         {showMenuPopup && (
           <Modal>
-            <TopMenu name={name || account} fixed />
+            <TopMenu 
+              logoUrl={logoUrl}
+              logoTitle={logoTitle}
+              fixed
+            />
           </Modal>
         )}
         <div

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -2,20 +2,24 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { intlShape, injectIntl } from 'react-intl'
 import SearchBar from 'vtex.storecomponents/SearchBar'
+import Logo from 'vtex.store-components/Logo'
 
 import { ExtensionPoint } from 'render'
 
-const TopMenu = ({ name, intl, fixed }) => {
+const TopMenu = ({ logoUrl, logoTitle, intl, fixed }) => {
   const translate = id => intl.formatMessage({ id: `dreamstore.${id}` })
 
   return (
-    <div className={`${fixed ? 'fixed mt4 top-2 shadow-5' : 'top-0'} z-999 flex flex-wrap w-100 pa4 pa5-ns ph7-l bg-white tl`}>
+    <div className={`${fixed ? 'fixed mt4 top-2 shadow-5' : 'top-0'} z-999 flex flex-wrap justify-center w-100 pa4 pa5-ns ph7-l bg-white tl`}>
       <div className="flex pa4">
-        <a className="link b f3 near-black tc tl-ns serious-black" href="/">
-          {name}
+        <a className="link b f3 near-black tc tl-ns serious-black flex" href="/">
+          <Logo 
+            url={logoUrl}
+            title={logoTitle}
+          />
         </a>
       </div>
-      <div className="flex items-center flex-auto">
+      <div className="vtex-searchbar__container flex items-center flex-auto">
         <div className="w-100 flex pr8-ns">
           <div className="w-100">
             <SearchBar
@@ -33,7 +37,8 @@ const TopMenu = ({ name, intl, fixed }) => {
 }
 
 TopMenu.propTypes = {
-  name: PropTypes.string.isRequired,
+  logoUrl: PropTypes.string.isRequired,
+  logoTitle: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
   fixed: PropTypes.bool,
 }

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -37,8 +37,8 @@ const TopMenu = ({ logoUrl, logoTitle, intl, fixed }) => {
 }
 
 TopMenu.propTypes = {
-  logoUrl: PropTypes.string.isRequired,
-  logoTitle: PropTypes.string.isRequired,
+  logoUrl: PropTypes.string,
+  logoTitle: PropTypes.string,
   intl: intlShape.isRequired,
   fixed: PropTypes.bool,
 }

--- a/react/store-global.css
+++ b/react/store-global.css
@@ -26,3 +26,13 @@ body {
     display: none;
   }
 }
+
+.vtex-searchbar__container {
+  min-width: 350px;
+}
+
+@media only screen and (max-width: 400px) {
+  .vtex-searchbar__container {
+    min-width: 300px;
+  }
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Integrate the logo component to the store.

#### What problem is this solving?
Store was showing the label "storecomponents" instead of the logo.

#### How should this be manually tested?

#### Screenshots or example usage
<a href="https://gustavo--storecomponents.myvtex.com/">Workspace</a>

![captura de tela de 2018-06-05 17-25-01](https://user-images.githubusercontent.com/9275109/41000870-c33415e2-68e5-11e8-9f48-718e512d0360.png)

![captura de tela de 2018-06-05 17-25-32](https://user-images.githubusercontent.com/9275109/41000883-cc1a9de8-68e5-11e8-9443-35bb1c0ff788.png)

![captura de tela de 2018-06-05 17-25-25](https://user-images.githubusercontent.com/9275109/41000882-cacba6ee-68e5-11e8-829f-630e19c328e8.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
