### PR TITLE
Fix topbar space between top of the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Top bar space between the top of the page.
 
 ## [1.1.0] - 2018-6-8
 ### Added

--- a/react/Header.js
+++ b/react/Header.js
@@ -13,6 +13,7 @@ export const TOAST_TIMEOUT = 3000
 class Header extends Component {
   constructor(props) {
     super(props)
+    this._root = React.createRef()
     this.state = {
       isAddToCart: false,
       hasError: false,
@@ -33,6 +34,8 @@ class Header extends Component {
     document.addEventListener('message:error', this.handleError)
     document.addEventListener('item:add', this.handleItemAdd)
     document.addEventListener('scroll', this.handleScroll)
+
+    this.handleScroll()
   }
 
   componentWillUnmount() {
@@ -67,12 +70,12 @@ class Header extends Component {
   }
 
   handleScroll = () => {
-    if (!this._el) {
+    if (!this._root.current) {
       return
     }
 
     const scroll = window.scrollY
-    const { scrollHeight } = this._el
+    const { scrollHeight } = this._root.current
 
     if (scroll < scrollHeight && this.state.showMenuPopup) {
       this.setState({
@@ -86,28 +89,25 @@ class Header extends Component {
   }
 
   render() {
-    const { account } = global.__RUNTIME__
-    const { name, logoUrl, logoTitle } = this.props
+    const { logoUrl, logoTitle } = this.props
     const { isAddToCart, hasError, showMenuPopup, error } = this.state
 
     return (
       <div
         className="relative z-2 w-100 shadow-5"
-        ref={e => {
-          this._el = e
-        }}
+        ref={this._root}
       >
         <div className="z-2 items-center w-100 top-0 bg-white tl">
           <ExtensionPoint id="menu-link" />
         </div>
-        <TopMenu 
+        <TopMenu
           logoUrl={logoUrl}
           logoTitle={logoTitle}
         />
         <ExtensionPoint id="category-menu" />
         {showMenuPopup && (
           <Modal>
-            <TopMenu 
+            <TopMenu
               logoUrl={logoUrl}
               logoTitle={logoTitle}
               fixed

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -10,8 +10,8 @@ const TopMenu = ({ logoUrl, logoTitle, intl, fixed }) => {
   return (
     <div
       className={`${
-        fixed ? 'fixed mt4 top-2 shadow-5' : 'top-0'
-        } z-999 flex items-center flex-wrap w-100 pa4 pa5-ns ph8-l bg-white tl`}
+        fixed ? 'fixed top-0 shadow-5' : 'top-0'
+      } z-999 flex items-center flex-wrap w-100 pa4 pa5-ns ph8-l bg-white tl`}
     >
       <div className="flex pa4">
         <a className="link b f3 near-black tc tl-ns serious-black flex" href="/">


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove classes `mt-4` and replace `top-2` with `top-0` on the `TopBar` component.

#### What problem is this solving?
The topbar had a space between the top of the page and itself.

#### How should this be manually tested?
[Access this workspace](https://lucas--storecomponents.myvtex.com/).

#### Screenshots or example usage
- Issue:

![image](https://user-images.githubusercontent.com/10223856/41237023-ee9d960e-6d68-11e8-8500-408f07071af4.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
