### PR TITLE
Add the RelatedProducts component to the product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `vtex.shelf/RelatedProducts` component to the product page.
 
 ## [1.2.2] - 2018-6-15
 ### Fixed

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -50,6 +50,9 @@
     },
     "store/product/container/2": {
       "component": "vtex.product-details/ProductDetails"
+    },
+    "store/product/container/3": {
+      "component": "vtex.shelf/RelatedProducts"
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the RelatedProducts component to the product page

#### What problem is this solving?

The RelatedProducts component was not being used anywhere.

#### How should this be manually tested?

[Access the workspace](https://related--storecomponents.myvtex.com/samsung-s9/p)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/41622559-563a3672-73e6-11e8-989d-b75c410c050f.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
