### PR TITLE
Remove my-orders integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `pages.json` to inject `search-result` into `CategoryPage`
 
+### Fixed 
+- Remove the integration with `vtex.my-orders-app`. 
+
 ## [1.3.0] - 2018-6-20
 ### Added
 - Add `vtex.shelf/RelatedProducts` component to the product page.

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,6 @@
     "vtex.breadcrumb": "0.x",
     "vtex.login": "0.x",
     "vtex.styleguide": "4.x",
-    "vtex.my-orders-app": "0.x",
     "vtex.render-runtime": "7.9.x",
     "vtex.render-server": "7.4.x",
     "vtex.store": "0.x"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -3,9 +3,6 @@
     "store/theme": {
       "component": "Theme"
     },
-    "store/account/container/1": {
-      "component": "vtex.my-orders-app/index"
-    },
     "store/header": {
       "component": "Header"
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?
This integration is in `vtex.store` now. Don't need to be here. 

#### Screenshots or example usage
https://login--storecomponents.myvtexdev.com/account/orders#/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
