### PR TITLE
Add SearchResult to the brand page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `SearchResult` to the brand page.
 
 ## [1.3.2] - 2018-7-4
-### Chaged
+### Changed
 - Use `store-components/Header` instead internal component `Header`.
 
 ## [1.3.1] - 2018-6-27

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -36,6 +36,9 @@
     "store/search/container/1": {
       "component": "vtex.search-result/SearchResult"
     },
+    "store/brand/container/1": {
+      "component": "vtex.search-result/SearchResult"
+    },
     "store/department/container/1": {
       "component": "vtex.search-result/SearchResult"
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add SearchResult to the brand page

#### What problem is this solving?

The brand page had no components

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/samsung/b)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/42293473-dedc7d52-7fb0-11e8-8883-222a8de8704b.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
