### PR TITLE
Add login content component to login page extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add `SearchResult` to the brand page.
+- `vtex.login/LoginContent` to `store/login/container` extension point.
 
 ## [1.3.2] - 2018-7-4
 ### Changed

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -21,6 +21,9 @@
     "store/footer": {
       "component": "vtex.store-components/Footer"
     },
+    "store/login/container": {
+      "component": "vtex.login/LoginContent"
+    },
     "store/home/container": {
       "component": "vtex.render-runtime/ExtensionContainer"
     },

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -21,7 +21,10 @@
     "store/footer": {
       "component": "vtex.store-components/Footer"
     },
-    "store/login/container": {
+    "store/login/container/": {
+      "component": "vtex.render-runtime/ExtensionContainer"
+    },
+    "store/login/container/1": {
       "component": "vtex.login/LoginContent"
     },
     "store/home/container": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `vtex.login/LoginContent` to the empty extension point on the login page.

#### What problem is this solving?
The login page was empty.

#### How should this be manually tested?
[Access this workspace](https://logincss--storecomponents.myvtex.com/login), although I'm still working on it and it may be broken at sometimes.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
