### PR TITLE
Fix the my-orders rendering error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix the `my-orders` rendering error.
 
 ## [1.9.2] - 2018-07-27
 ### Changed

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -113,18 +113,16 @@
         }
       }
     },
-    "orders": {
+    "account": {
       "component": "vtex.render-runtime/LayoutContainer",
       "props": {
         "elements": [
-          "myOrdersApp"
+          "__children__"
         ]
-      },
-      "extensions": {
-        "myOrdersApp": {
-          "component": "vtex.my-orders-app/index"
-        }
       }
+    },
+    "orders": {
+      "component": "vtex.my-orders-app/index"
     },
     "simple": {
       "component": "vtex.render-runtime/LayoutContainer",
@@ -151,7 +149,7 @@
     "store/account": [
       {
         "name": "Default",
-        "template": "simple"
+        "template": "account"
       }
     ],
     "store/account/orders": [


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix issue that `my-orders-app` doesn't render when access `/account/orders`

#### How should this be manually tested?

#### Screenshots or example usage
https://bruno--storecomponents.myvtex.com/account/orders/

#### Types of changes
* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
